### PR TITLE
Make travis run yarn test from root folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,8 @@ env:
   - VER=`node -pe "require('./package.json')['version']"`
 
 script:
-  - cd packages/shared-utils
   - yarn install
-  - yarn test
-  - cd ../css-rules-engine
-  - yarn install
-  - yarn test
-  - cd ../js-rules-engine
-  - yarn install
+  - yarn install-all
   - yarn test
 
 services:


### PR DESCRIPTION
Run `yarn test` (which runs all tests) from the root folder rather than `cd`-ing into each folder and running the individual tests.

This is good because we will no longer have to update `.travis.yml` whenever we add a new tool.
