### PR TITLE
Release script should not call 'yarn generate-files'

### DIFF
--- a/release/release-local.js
+++ b/release/release-local.js
@@ -16,8 +16,6 @@ const release = (shell, option, version) => {
     shell.echo("Building...");
     r = shell.exec(`yarn install`);
     if(r.code != 0) { shell.exit(r.code); }
-    r = shell.exec(`yarn generate-files`);
-    if(r.code != 0) { shell.exit(r.code); }
     r = shell.exec(`echo { "version": "${version}" }>version.json`);
     if(r.code != 0) { shell.exit(r.code); }
     r = shell.exec(`yarn build:release`);

--- a/release/release-local.test.js
+++ b/release/release-local.test.js
@@ -10,7 +10,6 @@ test('test that --start option runs the correct commands', () => {
     "git checkout -b v0.10.0",
     "git push --set-upstream origin v0.10.0",
     "yarn install",
-    "yarn generate-files",
     "echo { \"version\": \"0.10.0\" }>version.json",
     "yarn build:release",
   ];


### PR DESCRIPTION
The generate-files/server.js bug has been fixed so there is no need to call `yarn generate-files` in the release script anymore.