### PR TITLE
Release script updates

### DIFF
--- a/acceptance-tests/scripts/dummy-files/has-updates.css
+++ b/acceptance-tests/scripts/dummy-files/has-updates.css
@@ -2,14 +2,17 @@
   background-color: green;
 }
 
-/* We expect 'div.cluster h3' to be removed */
+/* Expect 'div.cluster h3' to be removed. */
 
 .foo,
 div.cluster h3 {
   background-color: yellow;
 }
 
-/* We expect 'div.cluster td.top' to be replaced with 'div.bx--cluster .top' */
+/*
+ * Old: div.cluster td.top
+ * New: div.bx--cluster .top
+ */
 
 .soria div.cluster td.top {
   background-color: yellow;

--- a/release/release-local.js
+++ b/release/release-local.js
@@ -35,6 +35,10 @@ const release = (shell, option, version) => {
     if(r.code != 0) { shell.exit(r.code); }
     r = shell.exec(`yarn docker-tasks release latest`);
     if(r.code != 0) { shell.exit(r.code); }
+    r = shell.exec(`yarn docker-tasks release ${version} --public`);
+    if(r.code != 0) { shell.exit(r.code); }
+    r = shell.exec(`yarn docker-tasks release latest --public`);
+    if(r.code != 0) { shell.exit(r.code); }
     r = shell.exec(`git tag v${version}`);
     if(r.code != 0) { shell.exit(r.code); }
     r = shell.exec(`git push --tags`);

--- a/release/release-local.js
+++ b/release/release-local.js
@@ -8,17 +8,17 @@ const release = (shell, option, version) => {
   }
 
   if(option === "--start") {
-    shell.echo("Creating release branch...");
-    r = shell.exec(`git checkout -b v${version}`);
-    if(r.code != 0) { shell.exit(r.code); }
-    r = shell.exec(`git push --set-upstream origin v${version}`);
-    if(r.code != 0) { shell.exit(r.code); }
     shell.echo("Building...");
     r = shell.exec(`yarn install`);
     if(r.code != 0) { shell.exit(r.code); }
     r = shell.exec(`echo { "version": "${version}" }>version.json`);
     if(r.code != 0) { shell.exit(r.code); }
     r = shell.exec(`yarn build:release`);
+    if(r.code != 0) { shell.exit(r.code); }
+    shell.echo("Creating release branch...");
+    r = shell.exec(`git checkout -b v${version}`);
+    if(r.code != 0) { shell.exit(r.code); }
+    r = shell.exec(`git push --set-upstream origin v${version}`);
     if(r.code != 0) { shell.exit(r.code); }
     shell.echo("");
     shell.echo("Build successful. You should now perform acceptance testing. Use `yarn at:build` and `at.bat`/`at.sh` to test against generated acceptance test data.");

--- a/release/release-local.test.js
+++ b/release/release-local.test.js
@@ -7,11 +7,11 @@ afterEach(() => {
 
 test('test that --start option runs the correct commands', () => {
   const expected = [
-    "git checkout -b v0.10.0",
-    "git push --set-upstream origin v0.10.0",
     "yarn install",
     "echo { \"version\": \"0.10.0\" }>version.json",
     "yarn build:release",
+    "git checkout -b v0.10.0",
+    "git push --set-upstream origin v0.10.0",
   ];
 
   release(dummyShell, "--start", "0.10.0");

--- a/release/release-local.test.js
+++ b/release/release-local.test.js
@@ -25,6 +25,8 @@ test('test that --ship option runs the correct commands', () => {
     "docker login wh-govspm-docker-local.artifactory.swg-devops.com",
     "yarn docker-tasks release 0.10.0",
     "yarn docker-tasks release latest",
+    "yarn docker-tasks release 0.10.0 --public",
+    "yarn docker-tasks release latest --public",
     "git tag v0.10.0",
     "git push --tags",
     "rm -f version.json",


### PR DESCRIPTION
- Release script now builds before creating the release branch
- Release script now pushes public image as well as private image
- Update comment in acceptance test data to be easier to read on the narrow columns of the diff screen
