### PR TITLE
Add utils.init(config) method to make writing tools easier

### DIFF
--- a/docs/dev/adding_a_new_service.md
+++ b/docs/dev/adding_a_new_service.md
@@ -6,9 +6,15 @@
 2. Your new service should be feature flagged off while it is being built by setting `enabled: false`. You will still be able to run it via a developer shortcut (see below.)
 3. Create a new package with an `index.js` file containing an `execute` method. This method will be triggered when the IDE shortcut is invoked.
 ```
-const execute = () => {
+const utils = require("../shared-utils/sharedUtils");
+
+const execute = overrides => {
+  const config = { ...utils.loadConfig(), ...overrides };
+  utils.init(config);
+
   console.log("Hello, world!");
 }
+
 module.exports = { execute };
 ```
 4. Update `package.json` `scripts: { }` section to include `install:your-service`
@@ -32,7 +38,8 @@ FIXME (Step 7) Can we automatically map the source code in `dev.bat`/`dev.sh` if
 
 ## Notes
 
+- The first two lines of config/init boilerplate allow the service to be run independently and as part of the main service.
 - To build and test your tool while keeping it hidden from the customer, `build:dev` generates additional shortcuts to every individual service, regardless if whether they are enabled or not.
-- `main-service` is triggered via the "Run SPM UI Upgrade Helper" shortcut. It will trigger all enabled tools.
+- `main-service` is triggered via the "Run SPM UI Upgrade Helper" shortcut. It will trigger enabled tools only.
 - When the Docker container starts, the `code-generation` package uses the data in `config/tools.json` to generate a `server.js` file for each package. It also generates Eclipse Theia plugins as `packages/vs-upgrade-helper-plugin/src/functions.ts`.
 - Flagging the features off during development means you can can continue to commit to `main` every day. This means no long-lived feature branches which means no painful merges, and if your branch breaks something you find out today.

--- a/packages/css-rules-engine/index.js
+++ b/packages/css-rules-engine/index.js
@@ -11,14 +11,15 @@ const utils = require("../shared-utils/sharedUtils");
 const execute = (overrides = {}) => {
   try {
     const config = { ...utils.loadConfig(), ...overrides };
-    let targetFiles = config.files;
+    utils.init(config);
 
     // Initial setup
-    if(!config.skipSetup) {
-      utils.removeOutputFolder(config);
-      utils.createGitRepo(config);
-      targetFiles = utils.globAllFiles(config);
-    }
+    let targetFiles = config.files;
+    // if(!config.skipSetup) {
+    //   utils.removeOutputFolder(config);
+    //   utils.createGitRepo(config);
+    //   targetFiles = utils.globAllFiles(config);
+    // }
     targetFiles = utils.filterFiles(targetFiles, "css");
 
     // Apply the rules to the files

--- a/packages/css-rules-engine/index.test.js
+++ b/packages/css-rules-engine/index.test.js
@@ -1,4 +1,4 @@
-const { testWithDataFolder } = require("test-with-data-folder");
+const testWithDataFolder = require("test-with-data-folder");
 const { execute } = require("./index");
 
 test('css-rules-engine test', () => {

--- a/packages/css-rules-engine/package.json
+++ b/packages/css-rules-engine/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "jest": "^26.0.1",
-    "test-with-data-folder": "^0.0.4"
+    "test-with-data-folder": "^0.0.7"
   }
 }

--- a/packages/css-rules-engine/test-data/test-case-1/expected/no-changes.css
+++ b/packages/css-rules-engine/test-data/test-case-1/expected/no-changes.css
@@ -1,0 +1,4 @@
+/**
+ * There should be no changes to this file as no rules will affect it. No prettifying, no formatting, nothing!
+ */
+.do-not-change { background-color: green; }

--- a/packages/css-rules-engine/yarn.lock
+++ b/packages/css-rules-engine/yarn.lock
@@ -4780,10 +4780,10 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-test-with-data-folder@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/test-with-data-folder/-/test-with-data-folder-0.0.4.tgz#ccb7ae89b4a1fdb99bc108dfc582a74376efb99c"
-  integrity sha512-th8i18WFXZHDaxkaWDVn+7tbnciEOewiqKM//SedfAFffWz+TEzRnwlle/hEsAaHPfxvX16aZ9YGQ3d+5v1kBw==
+test-with-data-folder@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/test-with-data-folder/-/test-with-data-folder-0.0.7.tgz#d3be583f1cffc42cc78f662cae29994bd6712c2a"
+  integrity sha512-tVQ4Qcg56ec2GcPqvphh224WAuSHZeQfmUWWaFjEz0e9Yx5OnbNxGqMNDDf8ksmC/CLHcHlz9ug9sK9/Dox3nA==
   dependencies:
     "@folkforms/file-io" "^0.2.2"
     shelljs "^0.8.4"

--- a/packages/service-main/index.js
+++ b/packages/service-main/index.js
@@ -9,18 +9,17 @@ const utils = require("../shared-utils/sharedUtils");
  */
 const execute = (testConfigOverrides = {}, testToolOverrides = []) => {
   try {
-    // Initial setup
-    const tools = testToolOverrides.length > 0 ? testToolOverrides : fileio.readJson("../../config/tools.json");
+    // Load configuration (and apply any test overrides provided)
     const config = { ...utils.loadConfig(), ...testConfigOverrides };
-    utils.removeOutputFolder(config);
-    utils.createGitRepo(config);
-    let inputFiles = utils.globAllFiles(config);
-    inputFiles = utils.removeIgnoredFiles(config, inputFiles);
-    utils.copyFilesToOutputFolder(config, inputFiles);
-    utils.commitFiles(config.outputFolder, "Initial commit");
-    const files = utils.flipToOutputFiles(config, inputFiles);
-    const configOverrides = { skipSetup: true, files };
+    const tools = testToolOverrides.length > 0 ? testToolOverrides : fileio.readJson("../../config/tools.json");
 
+    // Init the output folder and set config.files
+    utils.init(config);
+
+    // Pass configuration to the individual tools so we can tell them to skip the init step
+    const configOverrides = { ...config, skipInit: true };
+
+    // Execute all the tools
     tools.forEach(tool => {
       if(tool.package === "service-main") { return; } // Skip main tool
 

--- a/packages/shared-utils/sharedUtils.js
+++ b/packages/shared-utils/sharedUtils.js
@@ -12,6 +12,7 @@ const {
   flipToOutputFiles
 } = require("./src/filesAndFolders");
 const { removeIgnoredFiles } = require("./src/removeIgnoredFiles");
+const { init } = require("./src/init");
 
 module.exports = {
   // config.js
@@ -35,4 +36,6 @@ module.exports = {
   flipToOutputFiles,
   // removeIgnoredFiles.js
   removeIgnoredFiles,
+  // init.js
+  init,
 };

--- a/packages/shared-utils/src/config.js
+++ b/packages/shared-utils/src/config.js
@@ -16,7 +16,7 @@ const loadConfig = (overrides = {}) => {
     ignorePatternsFolderAdditional: overrides.ignorePatternsFolderAdditional || "/home/workspace/ignore",
     iconReferenceExclude: overrides.iconReferenceExclude || ["zip", "class", "jpg", "jpeg", "gif", "png"],
     verbose: overrides.verbose || false,
-    skipSetup: overrides.skipSetup || false,
+    skipInit: overrides.skipInit || false,
     files: overrides.files || [],
   };
   return config;

--- a/packages/shared-utils/src/config.test.js
+++ b/packages/shared-utils/src/config.test.js
@@ -10,7 +10,7 @@ test('config test with defaults', () => {
     ignorePatternsFolderAdditional: "/home/workspace/ignore",
     iconReferenceExclude: ["zip", "class", "jpg", "jpeg", "gif", "png"],
     verbose: false,
-    skipSetup: false,
+    skipInit: false,
     files: [],
   }
 
@@ -29,7 +29,7 @@ test('config test with all overrides', () => {
     ignorePatternsFolderAdditional: "fff",
     iconReferenceExclude: "ggg",
     verbose: "hhh",
-    skipSetup: true,
+    skipInit: true,
     files: [],
   }
   const expected = overrides;
@@ -56,7 +56,7 @@ test('config test with some overrides', () => {
     ignorePatternsFolderAdditional: "fff",
     iconReferenceExclude: ["zip", "class", "jpg", "jpeg", "gif", "png"],
     verbose: "hhh",
-    skipSetup: false,
+    skipInit: false,
     files: [],
   };
 

--- a/packages/shared-utils/src/init.js
+++ b/packages/shared-utils/src/init.js
@@ -1,0 +1,41 @@
+const { createGitRepo, commitFiles } = require("./gitUtils");
+const { removeOutputFolder, globAllFiles, copyFilesToOutputFolder, flipToOutputFiles } = require("./filesAndFolders");
+const { removeIgnoredFiles } = require("./removeIgnoredFiles");
+
+/**
+ * The init step will create a git repo in the output folder, glob up the input files, remove any
+ * ignored files, copy the remaining files to the output folder and commit them, then add the
+ * file paths to the config object
+ *
+ * Tools should call the following code when they start:
+ * ```
+ *     const config = { ...utils.loadConfig(), ...overrides };
+ *     utils.init(config);
+ * ```
+ * This means when a tool is run independently it will set up the output folder itself and glob the
+ * files etc.
+ *
+ * When the main tool calls a tool it passes `{ skipInit: true, files }` as an override meaning the
+ * `init` step is skipped. We don't want each tool deleting and recreating the output folder or to
+ * have to glob the list of files over and over.
+ *
+ * @param {*} config configuration object
+ */
+const init = config => {
+  if(config.skipInit) {
+    console.log("Skipping init step");
+    return;
+  }
+
+  console.log("Initializing output folder");
+  removeOutputFolder(config);
+  createGitRepo(config);
+  let inputFiles = globAllFiles(config);
+  inputFiles = removeIgnoredFiles(config, inputFiles);
+  copyFilesToOutputFolder(config, inputFiles);
+  commitFiles(config.outputFolder, "Initial commit");
+  const files = flipToOutputFiles(config, inputFiles);
+  config.files = files;
+}
+
+module.exports = { init };

--- a/packages/shared-utils/src/init.test.js
+++ b/packages/shared-utils/src/init.test.js
@@ -1,0 +1,3 @@
+test('init dummy test ', () => {
+  expect(true).toEqual(true);
+});


### PR DESCRIPTION
Tools should start with this boilerplate:
```
const utils = require("../shared-utils/sharedUtils");

const execute = overrides => {
  const config = { ...utils.loadConfig(), ...overrides };
  utils.init(config);
```
This will create the git repo, glob up the files, copy them and assign to config.files, etc.

Also, this way if the tool is triggered from the main tool the init step will be skipped (because main will have run it already.)
