### PR TITLE
Remove ADDITIONAL_RULES option

### DIFF
--- a/spm-ui-upgrade-helper.bat
+++ b/spm-ui-upgrade-helper.bat
@@ -22,17 +22,11 @@ set VERSION=%1
 set INPUT_FOLDER_CMD=-v %2:/home/workspace/input
 set OUTPUT_FOLDER_CMD=-v %3:/home/workspace/output
 
-if "%4" == "" (
-  set ADDITIONAL_RULES_CMD=
-) else (
-  set ADDITIONAL_RULES_CMD=-v %4:/home/workspace/rules
-)
-
-:: Detach by default
-if "%DETACH%" == "false" (
-  set DETACH_CMD=
-) else (
+:: Attach by default
+if "%DETACH%" == "true" (
   set DETACH_CMD=--detach
+) else (
+  set DETACH_CMD=
 )
 
 echo Starting spm-ui-upgrade-helper
@@ -40,7 +34,6 @@ echo.
 echo     VERSION = %VERSION%
 echo     INPUT_FOLDER_CMD = %INPUT_FOLDER_CMD%
 echo     OUTPUT_FOLDER_CMD = %OUTPUT_FOLDER_CMD%
-echo     ADDITIONAL_RULES_CMD = %ADDITIONAL_RULES_CMD%
 echo     DETACH_CMD = %DETACH_CMD%
 echo.
 
@@ -49,14 +42,13 @@ call docker rm spm-ui-upgrade-helper
 echo Logging in to wh-govspm-docker-local.artifactory.swg-devops.com...
 call docker login wh-govspm-docker-local.artifactory.swg-devops.com
 call docker pull wh-govspm-docker-local.artifactory.swg-devops.com/artifactory/wh-govspm-docker-local/spm-ui-upgrade-helper/spm-ui-upgrade-helper:%VERSION%
-call docker run %DETACH_CMD% -p 3000:3000 -p 4000-4004:4000-4004 %UIUH_DEV_CMD% %INPUT_FOLDER_CMD% %OUTPUT_FOLDER_CMD% %ADDITIONAL_RULES_CMD% --name spm-ui-upgrade-helper wh-govspm-docker-local.artifactory.swg-devops.com/artifactory/wh-govspm-docker-local/spm-ui-upgrade-helper/spm-ui-upgrade-helper:%VERSION%
-call docker ps
+call docker run %DETACH_CMD% -p 3000:3000 -p 4000-4004:4000-4004 %UIUH_DEV_CMD% %INPUT_FOLDER_CMD% %OUTPUT_FOLDER_CMD% --name spm-ui-upgrade-helper wh-govspm-docker-local.artifactory.swg-devops.com/artifactory/wh-govspm-docker-local/spm-ui-upgrade-helper/spm-ui-upgrade-helper:%VERSION%
 endlocal
 
 goto end
 
 :printHelpAndExit
-echo Usage: spm-ui-upgrade-helper.bat ^<version^> ^<input folder^> ^<output folder^> [^<additional rules^>] [^<additional ignore^>]
+echo Usage: spm-ui-upgrade-helper.bat ^<version^> ^<input folder^> ^<output folder^>
 exit /B 1
 
 :end

--- a/spm-ui-upgrade-helper.sh
+++ b/spm-ui-upgrade-helper.sh
@@ -22,16 +22,10 @@ VERSION=$1
 INPUT_FOLDER_CMD="-v $2:/home/workspace/input"
 OUTPUT_FOLDER_CMD="-v $3:/home/workspace/output"
 
-if [[ -z "$4" ]]; then
-  ADDITIONAL_RULES_CMD=
-else
-  ADDITIONAL_RULES_CMD="-v $4:/home/workspace/rules"
-fi
-
-if [[ "$DETACH" == "false" ]]; then
-  DETACH_CMD=
-else
+if [[ "$DETACH" == "true" ]]; then
   DETACH_CMD=--detach
+else
+  DETACH_CMD=
 fi
 
 echo Starting spm-ui-upgrade-helper
@@ -39,7 +33,6 @@ echo
 echo     VERSION = $VERSION
 echo     INPUT_FOLDER_CMD = $INPUT_FOLDER_CMD
 echo     OUTPUT_FOLDER_CMD = $OUTPUT_FOLDER_CMD
-echo     ADDITIONAL_RULES_CMD = $ADDITIONAL_RULES_CMD
 echo     DETACH_CMD = $DETACH_CMD
 echo
 
@@ -54,8 +47,6 @@ docker run $DETACH_CMD -p 3000:3000 -p 4000-4004:4000-4004 \
     $UIUH_DEV_CMD \
     $INPUT_FOLDER_CMD \
     $OUTPUT_FOLDER_CMD \
-    $ADDITIONAL_RULES_CMD \
     --name spm-ui-upgrade-helper \
     wh-govspm-docker-local.artifactory.swg-devops.com/artifactory/wh-govspm-docker-local/spm-ui-upgrade-helper/spm-ui-upgrade-helper:$VERSION
 if [ "$?" != 0 ]; then echo "Error: Could not run $VERSION version."; exit 1; fi
-docker ps


### PR DESCRIPTION
If we do ever need this option we should implement it via a more generalised config e.g. a `.spm-uiuh-config` file where we can add additional options, rather than adding lots of command-line args.

This way also helps keep the batch files and shell scripts as simple, clean and static as possible, which is important because those files are manual downloads for the customer.
