### PR TITLE
Remove .md extensions from links

### DIFF
--- a/docs/customer/customer_font_replacement.md
+++ b/docs/customer/customer_font_replacement.md
@@ -1,4 +1,4 @@
-[<< Back to the index](../index.md)
+[<< Back to the index](../index)
 
 # Replacing font-faces in SPM
 

--- a/docs/customer/customer_ignores.md
+++ b/docs/customer/customer_ignores.md
@@ -1,4 +1,4 @@
-[<< Back to the UI Upgrade Helper guide](../ui_upgrade_helper_guide.md)
+[<< Back to the UI Upgrade Helper guide](../ui_upgrade_helper_guide)
 
 # Ignoring files
 

--- a/docs/dev/adding_a_new_tool.md
+++ b/docs/dev/adding_a_new_tool.md
@@ -1,4 +1,4 @@
-[<< Back to the developer guide](../developer_guide.md)
+[<< Back to the developer guide](../developer_guide)
 
 # Adding a new tool
 

--- a/docs/dev/adding_new_rules.md
+++ b/docs/dev/adding_new_rules.md
@@ -1,7 +1,7 @@
-[<< Back to the developer guide](../developer_guide.md)
+[<< Back to the developer guide](../developer_guide)
 
 # Adding New Rules
 
 OOTB rules are stored in the `packages/config/rules` folder.
 
-See the [css-rules-tool guide](../overview.md) for details on the ordering of the rules.
+See the [css-rules-tool guide](../overview) for details on the ordering of the rules.

--- a/docs/dev/coding.md
+++ b/docs/dev/coding.md
@@ -1,4 +1,4 @@
-[<< Back to the developer guide](../developer_guide.md)
+[<< Back to the developer guide](../developer_guide)
 
 # Coding
 

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -1,4 +1,4 @@
-[<< Back to the developer guide](../developer_guide.md)
+[<< Back to the developer guide](../developer_guide)
 
 # Debugging
 

--- a/docs/dev/installation.md
+++ b/docs/dev/installation.md
@@ -1,4 +1,4 @@
-[<< Back to the developer guide](../developer_guide.md)
+[<< Back to the developer guide](../developer_guide)
 
 # Installation
 

--- a/docs/dev/project_overview.md
+++ b/docs/dev/project_overview.md
@@ -1,4 +1,4 @@
-[<< Back to the developer guide](../developer_guide.md)
+[<< Back to the developer guide](../developer_guide)
 
 # Project Overview
 

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -1,4 +1,4 @@
-[<< Back to the developer guide](../developer_guide.md)
+[<< Back to the developer guide](../developer_guide)
 
 # Releasing
 

--- a/docs/dev/running_the_tool.md
+++ b/docs/dev/running_the_tool.md
@@ -1,4 +1,4 @@
-[<< Back to the developer guide](../developer_guide.md)
+[<< Back to the developer guide](../developer_guide)
 
 ## Running the UI Upgrade Helper tool
 

--- a/docs/dev/tests.md
+++ b/docs/dev/tests.md
@@ -1,4 +1,4 @@
-[<< Back to the developer guide](../developer_guide.md)
+[<< Back to the developer guide](../developer_guide)
 
 ## Tests
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,13 +1,13 @@
-[<< Back to home](index.md)
+[<< Back to home](index)
 
 # Developer Guide
 
-- [Project Overview](dev/project_overview.md)
-- [Installation](dev/installation.md)
-- [Running the tool](dev/running_the_tool.md)
-- [Running the tests](dev/tests.md)
-- [Coding](dev/coding.md)
-- [Adding a new tool](dev/adding_a_new_tool.md)
-- [Adding new rules to the css-rules-tool](dev/adding_new_rules.md)
-- [Debugging](dev/debugging.md)
-- [Releasing](dev/releasing.md)
+- [Project Overview](dev/project_overview)
+- [Installation](dev/installation)
+- [Running the tool](dev/running_the_tool)
+- [Running the tests](dev/tests)
+- [Coding](dev/coding)
+- [Adding a new tool](dev/adding_a_new_tool)
+- [Adding new rules to the css-rules-tool](dev/adding_new_rules)
+- [Debugging](dev/debugging)
+- [Releasing](dev/releasing)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Getting started
 
-- [Overview](overview.md)
-- [UI Upgrade Helper Guide](ui_upgrade_helper_guide.md)
-- [Customer Font Replacement Guide](customer/customer_font_replacement.md)
+- [Overview](overview)
+- [UI Upgrade Helper Guide](ui_upgrade_helper_guide)
+- [Customer Font Replacement Guide](customer/customer_font_replacement)
 - [Repository](https://github.com/IBM/spm-ui-upgrade-helper)
-- [UI Upgrade Helper Developer's Guide](developer_guide.md)
+- [UI Upgrade Helper Developer's Guide](developer_guide)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,14 +1,14 @@
-[<< Back to home](index.md)
+[<< Back to home](index)
 
 # Overview
 
 The SPM UI Upgrade Helper helps to automates the upgrade process by applying the same UI changes we have made to v8 to a customer's 7.0.11.0 development environment.
 
-To get started, see the [UI Upgrade Helper guide](ui_upgrade_helper_guide.md).
+To get started, see the [UI Upgrade Helper guide](ui_upgrade_helper_guide).
 
 ## Tools
 
-All of the tools are run sequentially via a single command, as detailed in the [UI Upgrade Helper guide](ui_upgrade_helper_guide.md).
+All of the tools are run sequentially via a single command, as detailed in the [UI Upgrade Helper guide](ui_upgrade_helper_guide).
 
 ### CSS Rules Tool
 

--- a/docs/ui_upgrade_helper_guide.md
+++ b/docs/ui_upgrade_helper_guide.md
@@ -1,4 +1,4 @@
-[<< Back to home](index.md)
+[<< Back to home](index)
 
 # UI Upgrade Helper Guide
 
@@ -54,7 +54,7 @@ Once installed, you will need to allow Docker Desktop to access certain paths on
 7. The files in `<input folder>` will be scanned and the results placed in `<output folder>`.
 8.  Click the `Source Control: Git` button on the left sidebar to inspect the changes.
 
-<img style="text-align:center" src="images/upgrade-helper.gif" width="500">
+![FIXME alt text](images/upgrade-helper.gif "FIXME title")
 
 9. Copy the contents of `<output folder>` into your v8 development environment.
 10. Build and test v8.
@@ -73,7 +73,7 @@ If your installation is non-standard, you might need to update the ignore files 
 
 ### Ignoring files
 
-See the [ignoring files page](customer/customer_ignores.md) for steps to ignore certain files and folders.
+See the [ignoring files page](customer/customer_ignores) for steps to ignore certain files and folders.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Remove `.md` extensions from links in docs. This way they still work when converted to Gatsby files.