### PR TITLE
Refactor window-sizing-tool engine and rules to improve readability

### DIFF
--- a/packages/window-size-tool/rules.json
+++ b/packages/window-size-tool/rules.json
@@ -24,10 +24,12 @@
   },
   {
     "width": "> 768",
-    "anyTerms": [
-     "(count(//CLUSTER) > 0 or count(//LIST) > 0) and count(//CLUSTER[@NUM_COLS >= 2]//LIST) = 0 and count(//CLUSTER[@NUM_COLS > 2]) = 0 and count(//LIST[count(FIELD | CONTAINER) > 4]) = 0"
-    ],
+    "anyTerms": [],
     "allTerms": [
+      "count(//CLUSTER) > 0 or count(//LIST) > 0",
+      "count(//CLUSTER[@NUM_COLS >= 2]//LIST) = 0",
+      "count(//CLUSTER[@NUM_COLS > 2]) = 0",
+      "count(//LIST[count(FIELD | CONTAINER) > 4]) = 0",
       "count(//INCLUDE) = 0",
       "count(//MENU[@MODE='WIZARD_PROGRESS_BAR']) = 0"  
      ],
@@ -47,10 +49,11 @@
   },
   {
     "width": "> 576 and <= 768",
-    "anyTerms": [
-      "count(//CLUSTER[@NUM_COLS > 1 ]) = 0 and count(//LIST[count(FIELD | CONTAINER) > 2]) = 0 and (count(//CLUSTER) > 0 or count(//LIST) > 0)"
-    ],
+    "anyTerms": [],
     "allTerms": [
+      "count(//CLUSTER[@NUM_COLS > 1 ]) = 0",
+      "count(//LIST[count(FIELD | CONTAINER) > 2]) = 0",
+      "count(//CLUSTER) > 0 or count(//LIST) > 0",
       "count(//INCLUDE) = 0",
       "count(//MENU[@MODE='WIZARD_PROGRESS_BAR']) = 0"  
      ],
@@ -73,10 +76,15 @@
   },
   {
     "width": "> 420 and <= 576",
-    "anyTerms": [
-      "count(//CLUSTER[@NUM_COLS > 1 ]) = 0 and count(//CLUSTER) = 1 and count(//CLUSTER[count(FIELD | CONTAINER) > 2]) = 0 and count(//LIST) = 0 and count(//FIELD//TARGET) = 0 and count(//WIDGET//TARGET) = 0 and count(//ACTION_CONTROL) < 3"
-    ],
+    "anyTerms": [],
     "allTerms": [
+      "count(//CLUSTER[@NUM_COLS > 1 ]) = 0",
+      "count(//CLUSTER) = 1",
+      "count(//CLUSTER[count(FIELD | CONTAINER) > 2]) = 0",
+      "count(//LIST) = 0",
+      "count(//FIELD//TARGET) = 0",
+      "count(//WIDGET//TARGET) = 0",
+      "count(//ACTION_CONTROL) < 3",
       "count(//INCLUDE) = 0",
       "count(//MENU[@MODE='WIZARD_PROGRESS_BAR']) = 0"  
      ],

--- a/packages/window-size-tool/src/engine.js
+++ b/packages/window-size-tool/src/engine.js
@@ -108,36 +108,40 @@ function checkRule(node, rule, verbose = true) {
   } else if (!rule) {
     throw Error("You must supply a rules object");
   }
-  rule.anyTerms.forEach((term) => {
-    if (!pass) {
-      const result = xp.select(term, node);
+  if (rule.anyTerms.length > 0) {
+    rule.anyTerms.forEach((term) => {
+      if (!pass) {
+        const result = xp.select(term, node);
 
-      pass = pass || result;
+        pass = pass || result;
 
-      if (verbose) {
-        console.debug(
-          ` term:  ${
-            result ? chalk.green(`${result} `) : chalk.red(result)
-          } <- [${chalk.magenta(term)}]`
-        );
-      }
-    }
-    if (pass == true){
-        rule.allTerms.forEach((term) => {
-        if (pass) {
-          const result2 = xp.select(term, node);
-          pass = result2;
-          if (verbose) {
-            console.debug(
-              ` term:  ${
-                result2 ? chalk.green(`${result2} `) : chalk.red(result2)
-              } <- [${chalk.magenta(term)}]`
-            );
-          }
+        if (verbose) {
+          console.debug(
+            ` term:  ${
+              result ? chalk.green(`${result} `) : chalk.red(result)
+            } <- [${chalk.magenta(term)}]`
+          );
         }
-      });
-    }
-  });
+      }
+    });
+  } else if (rule.allTerms.length > 0) {
+    pass = true;
+  }
+  if (pass == true) {
+    rule.allTerms.forEach((term) => {
+      if (pass) {
+        const result2 = xp.select(term, node);
+        pass = result2;
+        if (verbose) {
+          console.debug(
+            ` term:  ${
+              result2 ? chalk.green(`${result2} `) : chalk.red(result2)
+            } <- [${chalk.magenta(term)}]`
+          );
+        }
+      }
+    });
+  }
   return pass;
 }
 
@@ -151,12 +155,7 @@ function checkRule(node, rule, verbose = true) {
  * @param {boolean} usePixelWidths Determines whether width is set as a pixel value
  * or a size category.
  */
-function updateWidthOption(
-  windowOptions,
-  sizes,
-  target,
-  usePixelWidths
-) {
+function updateWidthOption(windowOptions, sizes, target, usePixelWidths) {
   if (!windowOptions) {
     throw Error("You must supply a WINDOW_OPTIONS string");
   } else if (!sizes) {
@@ -335,7 +334,7 @@ function applyRules(
       sizes,
       pagedictionary,
       usePixelWidths,
-      verbose,
+      verbose
     );
 
     // Only mark the files as 'for writing' if the contents changed


### PR DESCRIPTION
- Improves readability of rules with a single express in `anyTerms` that contains multiple AND conditions by converting them to multiple items in the allTerms array.
- Adjusts the engine to cater for `anyTerms` being empty. The checking of `allTerms` is no longer nested in the `anyTerms` loop