### PR TITLE
SPM-127949 Replacing the successful and unsuccessful icons

### DIFF
--- a/packages/icon-replacer-tool/icon_mappings.json
+++ b/packages/icon-replacer-tool/icon_mappings.json
@@ -276,5 +276,7 @@
   "person_grey_child.png": "avatar__child--125-enabled.svg",
   "icon_days_left.png": "days-left—20-enabled.svg",
   "icon_reaching_time_limit.png": "days-reaching-limit--20-enabled.svg",
-  "icon_reaching_time_limit_hover.png": "days-reaching-limit--20-enabled.svg"
+  "icon_reaching_time_limit_hover.png": "days-reaching-limit--20-enabled.svg",
+  "image_unsuccessful.png": "line__filled--20-enabled.svg",
+  "image_successful.png ": "done__filled--20-enabled two.svg"
 }

--- a/packages/icon-replacer-tool/icon_mappings.json
+++ b/packages/icon-replacer-tool/icon_mappings.json
@@ -278,5 +278,6 @@
   "icon_reaching_time_limit.png": "days-reaching-limit--20-enabled.svg",
   "icon_reaching_time_limit_hover.png": "days-reaching-limit--20-enabled.svg",
   "image_unsuccessful.png": "line__filled--20-enabled.svg",
-  "image_successful.png ": "done__filled--20-enabled two.svg"
+  "image_successful.png": "done__filled--20-enabled two.svg",
+  "to_do_tick.png": "done__filled--20-enabled two.svg"
 }

--- a/packages/icon-replacer-tool/icon_mappings.json
+++ b/packages/icon-replacer-tool/icon_mappings.json
@@ -279,5 +279,6 @@
   "icon_reaching_time_limit_hover.png": "days-reaching-limit--20-enabled.svg",
   "image_unsuccessful.png": "line__filled--20-enabled.svg",
   "image_successful.png": "done__filled--20-enabled two.svg",
-  "to_do_tick.png": "done__filled--20-enabled two.svg"
+  "to_do_tick.png": "done__filled--20-enabled two.svg",
+  "icon_incidents.png": "incidents__filled--20-enabled.svg"
 }

--- a/packages/icon-replacer-tool/source_files/done__filled--20-enabled two.svg
+++ b/packages/icon-replacer-tool/source_files/done__filled--20-enabled two.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="20" height="20" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10 1C5.02944 1 1 5.02944 1 10C1 14.9706 5.02944 19 10 19C14.9706 19 19 14.9706 19 10C19 7.61305 18.0518 5.32387 16.364 3.63604C14.6761 1.94821 12.3869 1 10 1Z" fill="#198038"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8.71429 13.594L5.5 10.3797L6.52253 9.35707L8.71429 11.5487L13.4779 6.78564L14.5037 7.80515L8.71429 13.594Z" fill="white"/>
+</svg>

--- a/packages/icon-replacer-tool/source_files/incidents__filled--20-enabled.svg
+++ b/packages/icon-replacer-tool/source_files/incidents__filled--20-enabled.svg
@@ -1,0 +1,15 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_71_2)">
+<ellipse cx="10" cy="10" rx="10" ry="10" transform="matrix(1 8.74228e-08 8.74228e-08 -1 0 20)" fill="#009D9A"/>
+<ellipse cx="6" cy="6" rx="6" ry="6" transform="matrix(1 8.74228e-08 8.74228e-08 -1 4 16)" fill="white"/>
+<ellipse cx="5" cy="5" rx="5" ry="5" transform="matrix(1 8.74228e-08 8.74228e-08 -1 5 15)" fill="#009D9A"/>
+<ellipse cx="4" cy="4" rx="4" ry="4" transform="matrix(1 8.74228e-08 8.74228e-08 -1 6 14)" fill="white"/>
+<circle cx="3" cy="3" r="3" transform="matrix(1 0 0 -1 7 13)" fill="#009D9A"/>
+<circle cx="2" cy="2" r="2" transform="matrix(1 0 0 -1 8 12)" fill="white"/>
+</g>
+<defs>
+<clipPath id="clip0_71_2">
+<rect width="20" height="20" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/packages/icon-replacer-tool/source_files/line__filled--20-enabled.svg
+++ b/packages/icon-replacer-tool/source_files/line__filled--20-enabled.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="20" height="20" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10 1C5.02944 1 1 5.02944 1 10C1 14.9706 5.02944 19 10 19C14.9706 19 19 14.9706 19 10C19 7.61305 18.0518 5.32387 16.364 3.63604C14.6761 1.94821 12.3869 1 10 1Z" fill="#EB6200"/>
+<rect x="4" y="9" width="12" height="2" fill="white"/>
+</svg>


### PR DESCRIPTION
SPM-127949: Replacing the successful and unsuccessful icons.
SPM-127879: Replacing the to_do_tick icon
SPM-128252: Replace incidents icon

Icons replaced with non-text-contrast compliant icons.