### PR TITLE
SPM-127949 Renamed successful and unsuccessful icons - updates

### DIFF
--- a/packages/icon-replacer-tool/icon_mappings.json
+++ b/packages/icon-replacer-tool/icon_mappings.json
@@ -277,8 +277,8 @@
   "icon_days_left.png": "days-left—20-enabled.svg",
   "icon_reaching_time_limit.png": "days-reaching-limit--20-enabled.svg",
   "icon_reaching_time_limit_hover.png": "days-reaching-limit--20-enabled.svg",
-  "image_unsuccessful.png": "line__filled--20-enabled.svg",
-  "image_successful.png": "done__filled--20-enabled two.svg",
-  "to_do_tick.png": "done__filled--20-enabled two.svg",
+  "image_unsuccessful.png": "unsuccessful__filled--20-enabled.svg",
+  "image_successful.png": "successful__filled--20-enabled.svg",
+  "to_do_tick.png": "successful__filled--20-enabled.svg",
   "icon_incidents.png": "incidents__filled--20-enabled.svg"
 }

--- a/packages/icon-replacer-tool/source_files/successful__filled--20-enabled.svg
+++ b/packages/icon-replacer-tool/source_files/successful__filled--20-enabled.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="20" height="20" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10 1C5.02944 1 1 5.02944 1 10C1 14.9706 5.02944 19 10 19C14.9706 19 19 14.9706 19 10C19 7.61305 18.0518 5.32387 16.364 3.63604C14.6761 1.94821 12.3869 1 10 1Z" fill="#198038"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8.71429 13.594L5.5 10.3797L6.52253 9.35707L8.71429 11.5487L13.4779 6.78564L14.5037 7.80515L8.71429 13.594Z" fill="white"/>
+</svg>

--- a/packages/icon-replacer-tool/source_files/unsuccessful__filled--20-enabled.svg
+++ b/packages/icon-replacer-tool/source_files/unsuccessful__filled--20-enabled.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="20" height="20" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10 1C5.02944 1 1 5.02944 1 10C1 14.9706 5.02944 19 10 19C14.9706 19 19 14.9706 19 10C19 7.61305 18.0518 5.32387 16.364 3.63604C14.6761 1.94821 12.3869 1 10 1Z" fill="#EB6200"/>
+<rect x="4" y="9" width="12" height="2" fill="white"/>
+</svg>


### PR DESCRIPTION
line__filled--20-enabled.svg  - renamed to - unsuccessful__filled--20-enabled.svg
done__filled--20-enabled two.svg - renamed to -  successful__filled--20-enabled.svg

Updates on the icon replacer tool.